### PR TITLE
Set `eventPath` to optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export default function linkState(component: any, key: string, eventPath: string): (e) => void;
+export default function linkState(component: any, key: string, eventPath?: string): (e) => void;


### PR DESCRIPTION
I guess the 3rd arg of `linkState` should be optional.