### PR TITLE
Fix compatibility with TSC option 'noImplicitAny'.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,5 @@
-export default function linkState(component: any, key: string, eventPath: string): (e) => void;
+export default function linkState<T>(
+  component: any,
+  key: string,
+  eventPath?: string
+): (e: T) => void;


### PR DESCRIPTION
I've recent come across the issue that the provided typings will cause an error in case `noImplicitAny: true` is provided as TSC compiler option.

The PR includes a change that changes to return type from `(e) => void` to `(e: T) => void`, where `T` is a generic parameter as a placeholder for the event. Picked up the generic since this enables a bit more type safety once is gets set explicitly.
Also changed the `eventPath` parameter to be optional, which it seems to be according to the documentation.

Note: Regularly, this typing would still be a bit too weak. Before typings where added to this project, I've been using a definition like this for a react project:
```
export default function linkstate<T>(
  component: React.Component<any, any>,
  key: string,
  eventPath?: string
): (e: React.SyntheticEvent<T>) => void;
```
However, this would result in an additional external dependency, which I'm not sure you'd like to have.