### PR TITLE
ts: Specify argument as any

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export default function linkState(component: any, key: string, eventPath?: string): (e) => void;
+export default function linkState(component: any, key: string, eventPath?: string): (e: any) => void;


### PR DESCRIPTION
Lots of people (me, for example), use the `noImplicitAny` option in typescript, which makes it so that a warning is displayed unless you directly specify a type. I was getting an error when using this library because it does not have type for one of the parameters.