### PR TITLE
Issue 3: Allow scalar values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ export default function linkState(component, key, eventPath) {
 		let t = e && e.target || this,
 			state = {},
 			obj = state,
-			v = typeof eventPath==='string' ? delve(e, eventPath) : t.nodeName ? (t.type.match(/^che|rad/) ? t.checked : t.value) : e,
+			v = typeof eventPath==='string' ? delve(e, eventPath) : (t && t.nodeName) ? (t.type.match(/^che|rad/) ? t.checked : t.value) : e,
 			i = 0;
 		for ( ; i<path.length-1; i++) {
 			obj = obj[path[i]] || (obj[path[i]] = !i && component.state[path[i]] || {});


### PR DESCRIPTION
Hey @developit, hope you are doing well!

Fixes developit/linkstate#3

Old gzip size: **305B**
New gzip size: **308B (+3B)**

This adds a guard against undefined `event.target` and `this` in linkState callback. This causes a scalar value to pass through instead of blowing up when accessing `nodeName` on `undefined`.

Let me know what you think, thanks!