### PR TITLE
Allow key to be an array

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export default function linkState(component: any, key: string, eventPath?: string): (e) => void;
+export default function linkState(component: any, key: string | string[], eventPath?: string): (e) => void;

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,12 @@ import delve from 'dlv';
 
 /** Create an Event handler function that sets a given state property.
  *	@param {Component} component	The component whose state should be updated
- *	@param {string} key				A dot-notated key path to update in the component's state
- *	@param {string} eventPath		A dot-notated key path to the value that should be retrieved from the Event or component
+ *	@param {string|string[]} key	A dot-notated key path to update in the component's state
+ *	@param {string} eventPath	A dot-notated key path to the value that should be retrieved from the Event or component
  *	@returns {function} linkedStateHandler
  */
 export default function linkState(component, key, eventPath) {
-	let path = key.split('.'),
+	let path = key instanceof Array ? key : key.split('.'),
 		cache = component.__lsc || (component.__lsc = {});
 
 	return cache[key+eventPath] || (cache[key+eventPath] = function(e) {


### PR DESCRIPTION
I ran into a usecase where the path to a state value had a key that contained a `.`. It was a url specifically that caused this. 

Starting size: 316 B
Ending size: 331 B