### PR TITLE
Add support for array indices in key path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,8 @@ export default function linkState(component, key, eventPath) {
 			v = typeof eventPath==='string' ? delve(e, eventPath) : t.nodeName ? (t.type.match(/^che|rad/) ? t.checked : t.value) : e,
 			i = 0;
 		for ( ; i<path.length-1; i++) {
-			obj = obj[path[i]] || (obj[path[i]] = !i && component.state[path[i]] || {});
+			let iv = /^(\d*)$/.test(path[i+1]) ? [] : {};
+			obj = obj[path[i]] || (obj[path[i]] = !i && component.state[path[i]] || iv);
 		}
 		obj[path[i]] = v;
 		component.setState(state);

--- a/test/index.js
+++ b/test/index.js
@@ -102,6 +102,21 @@ describe('linkstate', () => {
 			expect(component.setState).to.have.been.calledWith({nested: {state: {key: 'newValue'}}});
 		});
 
+		it('should set dot notated state key with index support appropriately', () => {
+			linkFunction = linkState(component,'nested.state.0.key');
+			let element = document.createElement('input');
+			element.type= 'text';
+			element.value = 'newValue';
+
+			linkFunction({
+				currentTarget: element,
+				target: element
+			});
+
+			expect(component.setState).to.have.been.calledOnce;
+			expect(component.setState).to.have.been.calledWith({nested: {state: [{key: 'newValue'}]}});
+		});
+
 	});
 
 	describe('linkState with eventPath argument', () => {


### PR DESCRIPTION
This PR adds support to generate an array when indices are used as part of the key path.

For example: `'nested.state.0.key'` creates this state: `{nested: {state: [{key: 'newValue'}]}}`.

Old gzip size: **311B**
New gzip size: **337B (+26B)**