### PR TITLE
3rd param is optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export default function linkState(component: any, key: string, eventPath: string): (e) => void;
+export default function linkState(component: any, key: string, eventPath?: string): (e) => void;


### PR DESCRIPTION
While the code does not make it obvious that 'eventPath' is optional (it creates cache entries that looks like this: "keyUndefined") the tests make it clear that the caller does not have to pass in this param.