### PR TITLE
fix: Correcting polyfill's entry in the root package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "unpkg": "./dist/linkstate.umd.js",
   "exports": {
     ".": "./dist/linkstate.module.js",
-    "./polyfill": "./dist/polyfill.module.js",
+    "./polyfill": "./polyfill/dist/polyfill.module.js",
     "./hook": "./hook/dist/hook.module.js",
     "./": "./"
   },


### PR DESCRIPTION
I made this back when the `/hook` export was fixed but forgot to make the PR.